### PR TITLE
fix: add steps and step-definitions to SPEC_FILE_PATTERN regex

### DIFF
--- a/packages/service/src/constants.ts
+++ b/packages/service/src/constants.ts
@@ -101,7 +101,7 @@ export const CONTEXT_CHANGE_COMMANDS = [
  * Existing pattern (kept for any external consumers)
  */
 export const SPEC_FILE_PATTERN =
-  /\/(test|spec|features|pageobjects|@wdio\/expect-webdriverio)\//i
+  /\/(test|spec|features|steps|step-definitions|pageobjects|@wdio\/expect-webdriverio)\//i
 
 /**
  * Parser options


### PR DESCRIPTION
Cucumber projects using a steps/ or step-definitions/ directory were not
matched by the stack frame filter, causing blank Actions/Source tabs and
slow test runs in the devtools debugger.