### PR TITLE
chore(fix): Ignore examples/ during publish and reference nightwatch-devtools dependencies the correct way/paths

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["examples", "@wdio/devtools-example-*"]
 }

--- a/examples/wdio/package.json
+++ b/examples/wdio/package.json
@@ -1,5 +1,7 @@
 {
   "name": "examples",
+  "version": "0.0.0",
+  "private": true,
   "type": "module",
   "devDependencies": {
     "@wdio/cli": "9.28.0",

--- a/packages/nightwatch-devtools/tsconfig.json
+++ b/packages/nightwatch-devtools/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src",
+    "rootDir": "..",
     "module": "Node16",
     "moduleResolution": "Node16",
     "target": "ES2022",
@@ -12,7 +12,12 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "ignoreDeprecations": "6.0"
+    "ignoreDeprecations": "6.0",
+    "baseUrl": ".",
+    "paths": {
+      "@wdio/devtools-backend": ["../backend/src/index.ts"],
+      "@wdio/devtools-backend/*": ["../backend/src/*"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## What & why

[//]: # (What does this PR change, and what problem does it solve? Link the issue it closes, if any.)
  Three independent fixes that clean up publishing and TypeScript resolution:

  1. Exclude example packages from changeset versioning
  2. Mark the WDIO example as private (matching the Nightwatch example)
  3. Add TypeScript path aliases so nightwatch-devtools can resolve its backend imports
## Type of change

[//]: # (Put an `x` in the boxes that apply.)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Polish (an improvement to an existing feature)
- [ ] Breaking change (existing behavior changes for users)
- [ ] Documentation
- [x] Internal (build, CI, dependencies, tooling)

## Packages touched

[//]: # (DevTools is a monorepo — checking these helps reviewers know where to look.)

- [ ] `shared` (types and contracts)
- [ ] `core` (framework-agnostic capture/reporting)
- [ ] `service` (WebdriverIO adapter)
- [x] `nightwatch-devtools` (Nightwatch adapter)
- [ ] `selenium-devtools` (Selenium adapter)
- [ ] `backend` (server)
- [ ] `app` (UI)
- [ ] `script` (page-injected runtime)

## Notes for reviewers

[//]: # (Anything non-obvious: design trade-offs, alternatives you ruled out, follow-ups. If this PR touches more than one adapter, say why the shared logic doesn't live in `core`.)

## Screenshots / recordings

[//]: # (Required for UI changes — before/after images or a short clip.)
