### PR TITLE
feat(elements): Add getSnapshot() with eN virtual element IDs 

### DIFF
--- a/.changeset/1783537178-445-71eb.md
+++ b/.changeset/1783537178-445-71eb.md
@@ -1,7 +1,0 @@
----
-"@wdio/elements": minor
----
-
-### 🚀 Features
-- Add getSnapshot() with eN virtual element IDs
-

--- a/.changeset/1783537178-445-71eb.md
+++ b/.changeset/1783537178-445-71eb.md
@@ -1,0 +1,7 @@
+---
+"@wdio/elements": minor
+---
+
+### 🚀 Features
+- Add getSnapshot() with eN virtual element IDs
+

--- a/.changeset/elements-snapshot.md
+++ b/.changeset/elements-snapshot.md
@@ -1,0 +1,18 @@
+---
+"@wdio/elements": minor
+"@wdio/devtools-service": minor
+---
+
+### 🚀 Features
+
+- **`getSnapshot()`** — single call for web and mobile that returns an AI-readable text tree with embedded `e1`, `e2`, … virtual element IDs plus an elements map for direct selector resolution. No post-processing required.
+- **`browser.getSnapshot()`** — WDIO runtime accessor registered by `@wdio/devtools-service` in the `before` hook, calling `getSnapshot()` directly with zero trace-mode overhead (no screenshot round-trip, no page-settling).
+
+### 🛠 Core additions (`@wdio/devtools-core` — private)
+
+- `buildSnapshot()` — platform-agnostic formatter converting flat `SnapshotNode[]` into text + elements map.
+- `accessibilityNodesToSnapshotNodes()` — web adapter from `AccessibilityNode[]`.
+- `jsonElementToSnapshotNodes()` — mobile adapter from `JSONElement` tree.
+- `isStatictextEchoedByParent()` — shared statictext echo-suppression helper.
+- New types: `SnapshotNode`, `SnapshotElement` (with `qualifiedSelector` for `.instance(N)` disambiguation), `SnapshotResult`.
+- `tagName` field on internal `MobileFlatNode`.

--- a/packages/core/src/element-snapshot.ts
+++ b/packages/core/src/element-snapshot.ts
@@ -106,28 +106,8 @@ export function serializeWebSnapshot(
     const indent = '  '.repeat(node.depth + 1) // +1 indents everything under the header
     const isInteractive = INTERACTIVE_ROLES.has(node.role)
 
-    // Skip statictext that merely echoes the parent link/button name.
-    // Example: link "Highlights" → a*=Highlights doesn't need
-    //   statictext "Highlights" as a child because it adds no information.
-    if (node.role === 'statictext' && node.name) {
-      let echoedByParent = false
-      for (let j = i - 1; j >= 0; j--) {
-        if (nodes[j].depth < node.depth) {
-          const parentRole = nodes[j].role
-          const parentName = nodes[j].name
-          if (
-            INTERACTIVE_ROLES.has(parentRole) &&
-            parentName &&
-            parentName.includes(node.name)
-          ) {
-            echoedByParent = true
-          }
-          break // only check the immediate structural parent
-        }
-      }
-      if (echoedByParent) {
-        continue
-      }
+    if (isStatictextEchoedByParent(nodes, i)) {
+      continue
     }
 
     // Heading gets level suffix: heading[2]
@@ -171,6 +151,35 @@ export function serializeWebSnapshot(
 // ---------------------------------------------------------------------------
 // Mobile snapshot helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Returns true when `nodes[index]` is a statictext whose accessible name
+ * is already echoed by its immediate interactive parent — such a node
+ * adds no information and should be suppressed from the output.
+ */
+function isStatictextEchoedByParent(
+  nodes: AccessibilityNode[],
+  index: number
+): boolean {
+  const node = nodes[index]!
+  if (node.role !== 'statictext' || !node.name) {
+    return false
+  }
+  for (let j = index - 1; j >= 0; j--) {
+    if (nodes[j]!.depth < node.depth) {
+      const parent = nodes[j]!
+      if (
+        INTERACTIVE_ROLES.has(parent.role) &&
+        parent.name &&
+        parent.name.includes(node.name)
+      ) {
+        return true
+      }
+      break
+    }
+  }
+  return false
+}
 
 /** Shorten fully-qualified Android/iOS class names to the last segment. */
 function simplifyTag(tagName: string): string {
@@ -771,11 +780,13 @@ export function serializeMobileSnapshot(
 
 /** Derive a tag name from a CSS selector prefix (e.g. "button*=Submit" → "button"). */
 function extractTagFromSelector(selector: string, fallback: string): string {
-  const match = selector.match(/^([a-z][a-z0-9]*)[*.#\[]/)
+  // Matches tag name followed by a CSS selector combinator or operator.
+  // Supports hyphenated custom elements (my-component) and pseudo-classes (:nth-of-type).
+  const match = selector.match(/^([a-z][a-z0-9]*(?:-[a-z][a-z0-9]*)*)[*.#\[:=(^$~]/)
   if (match) {
     return match[1]
   }
-  const spaceMatch = selector.match(/^([a-z][a-z0-9]*)\s/)
+  const spaceMatch = selector.match(/^([a-z][a-z0-9]*(?:-[a-z][a-z0-9]*)*)\s/)
   if (spaceMatch) {
     return spaceMatch[1]
   }
@@ -788,6 +799,14 @@ function findContextName(nodes: SnapshotNode[], index: number): string | undefin
   for (let i = index - 1; i >= 0; i--) {
     if (nodes[i].depth <= myDepth && nodes[i].name) {
       if (nodes[i].depth === myDepth && nodes[i].isInteractive) {
+        continue
+      }
+      // Suppressed tag-interactive nodes (isInteractive=false but role is a
+      // mobile-interactable label like 'statictext') shouldn't provide context
+      // at same depth — their name is label text, not a container identity.
+      // Mirrors mobileInferPurpose which skips same-depth nodes not in
+      // MOBILE_STRUCTURAL_ROLES (which excludes 'statictext').
+      if (nodes[i].depth === myDepth && nodes[i].role === 'statictext') {
         continue
       }
       return nodes[i].name
@@ -857,6 +876,7 @@ export function buildSnapshot(
 
       elements[eId] = {
         selector: node.selector,
+        ...(selector !== node.selector ? { qualifiedSelector: selector } : {}),
         tagName: node.tagName,
         role: node.role,
         text: node.name
@@ -898,24 +918,15 @@ export function accessibilityNodesToSnapshotNodes(
 
     const isInteractive = INTERACTIVE_ROLES.has(node.role)
 
-    // Skip statictext that merely echoes the parent interactive name
-    if (node.role === 'statictext' && node.name) {
-      let echoedByParent = false
-      for (let j = i - 1; j >= 0; j--) {
-        if (nodes[j].depth < node.depth) {
-          if (
-            INTERACTIVE_ROLES.has(nodes[j].role) &&
-            nodes[j].name &&
-            nodes[j].name.includes(node.name)
-          ) {
-            echoedByParent = true
-          }
-          break
-        }
-      }
-      if (echoedByParent) {
-        continue
-      }
+    if (isStatictextEchoedByParent(nodes, i)) {
+      continue
+    }
+
+    // Interactive nodes without a selector can't be acted on — skip them
+    // so they don't leak as non-actionable entries in the text tree.
+    // Matches the guard in serializeWebSnapshot (line 141).
+    if (isInteractive && !node.selector) {
+      continue
     }
 
     const tagName = isInteractive && node.selector

--- a/packages/core/src/element-snapshot.ts
+++ b/packages/core/src/element-snapshot.ts
@@ -5,7 +5,12 @@
  * text files that LLMs can consume without any parsing.
  */
 
-import type { AccessibilityNode } from './element-types.js'
+import type {
+  AccessibilityNode,
+  SnapshotNode,
+  SnapshotElement,
+  SnapshotResult
+} from './element-types.js'
 import type { JSONElement } from './locators/types.js'
 import { parseAndroidBounds, parseIOSBounds } from './locators/xml-parsing.js'
 import {
@@ -423,6 +428,7 @@ interface MobileFlatNode {
   /** True when the element has clickable/focusable/checkable — the intended tap target. */
   isExplicitInteractive: boolean
   isInViewport: boolean
+  tagName: string
 }
 
 /**
@@ -461,7 +467,8 @@ function collectMobileNodes(
         depth,
         isInteractive: false,
         isExplicitInteractive: false,
-        isInViewport: false
+        isInViewport: false,
+        tagName: element.tagName
       })
       return
     }
@@ -504,7 +511,8 @@ function collectMobileNodes(
     depth,
     isInteractive: interactive,
     isExplicitInteractive: explicit,
-    isInViewport: inViewport
+    isInViewport: inViewport,
+    tagName: element.tagName
   })
 
   for (const child of element.children || []) {
@@ -755,4 +763,213 @@ export function serializeMobileSnapshot(
 
   const lines = renderMobileNodes(nodes)
   return [header, ...lines].join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// Unified snapshot formatter — web + mobile share the same render pass.
+// ---------------------------------------------------------------------------
+
+/** Derive a tag name from a CSS selector prefix (e.g. "button*=Submit" → "button"). */
+function extractTagFromSelector(selector: string, fallback: string): string {
+  const match = selector.match(/^([a-z][a-z0-9]*)[*.#\[]/)
+  if (match) {
+    return match[1]
+  }
+  const spaceMatch = selector.match(/^([a-z][a-z0-9]*)\s/)
+  if (spaceMatch) {
+    return spaceMatch[1]
+  }
+  return fallback
+}
+
+/** Walk backwards to find the nearest structural container name for ∈ context. */
+function findContextName(nodes: SnapshotNode[], index: number): string | undefined {
+  const myDepth = nodes[index].depth
+  for (let i = index - 1; i >= 0; i--) {
+    if (nodes[i].depth <= myDepth && nodes[i].name) {
+      if (nodes[i].depth === myDepth && nodes[i].isInteractive) {
+        continue
+      }
+      return nodes[i].name
+    }
+  }
+  return undefined
+}
+
+/**
+ * Core formatter — converts a flat SnapshotNode[] into a text tree with
+ * eN virtual IDs and an elements map for selector resolution.
+ *
+ * Platform-agnostic: both web and mobile pipelines feed into this function.
+ */
+export function buildSnapshot(
+  header: string,
+  nodes: SnapshotNode[]
+): SnapshotResult {
+  const selectorCounts = new Map<string, number>()
+  for (const node of nodes) {
+    if (node.isInteractive && node.selector) {
+      selectorCounts.set(node.selector, (selectorCounts.get(node.selector) ?? 0) + 1)
+    }
+  }
+
+  const lines: string[] = [header]
+  const elements: Record<string, SnapshotElement> = {}
+  const selectorIndex = new Map<string, number>()
+  let counter = 1
+
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i]
+    const indent = '  '.repeat(node.depth + 1)
+
+    if (node.isInteractive && node.selector) {
+      let selector = node.selector
+      const total = selectorCounts.get(selector) ?? 1
+      if (total > 1) {
+        const idx = selectorIndex.get(selector) ?? 0
+        selectorIndex.set(selector, idx + 1)
+        selector = `${selector}.instance(${idx})`
+      }
+
+      const eId = `e${counter++}`
+
+      const roleLabel =
+        node.role === 'heading' && node.level
+          ? `heading[${node.level}]`
+          : node.role
+
+      const context = findContextName(nodes, i)
+      if (node.name && context) {
+        lines.push(
+          `${indent}${eId}  ${roleLabel} "${node.name}" ∈ "${context}"  →  ${selector}`
+        )
+      } else if (node.name) {
+        lines.push(
+          `${indent}${eId}  ${roleLabel} "${node.name}"  →  ${selector}`
+        )
+      } else if (context) {
+        lines.push(
+          `${indent}${eId}  ${roleLabel} ∈ "${context}"  →  ${selector}`
+        )
+      } else {
+        lines.push(`${indent}${eId}  ${roleLabel}  →  ${selector}`)
+      }
+
+      elements[eId] = {
+        selector: node.selector,
+        tagName: node.tagName,
+        role: node.role,
+        text: node.name
+      }
+    } else {
+      const roleLabel =
+        node.role === 'heading' && node.level
+          ? `heading[${node.level}]`
+          : node.role
+      lines.push(
+        node.name
+          ? `${indent}${roleLabel} "${node.name}"`
+          : `${indent}${roleLabel}`
+      )
+    }
+  }
+
+  return { text: lines.join('\n'), elements }
+}
+
+// ---------------------------------------------------------------------------
+// Web adapter — AccessibilityNode[] → SnapshotNode[]
+// ---------------------------------------------------------------------------
+
+export function accessibilityNodesToSnapshotNodes(
+  nodes: AccessibilityNode[],
+  options?: { inViewportOnly?: boolean }
+): SnapshotNode[] {
+  const { inViewportOnly = true } = options ?? {}
+
+  const result: SnapshotNode[] = []
+
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i]
+
+    if (inViewportOnly && node.isInViewport === false) {
+      continue
+    }
+
+    const isInteractive = INTERACTIVE_ROLES.has(node.role)
+
+    // Skip statictext that merely echoes the parent interactive name
+    if (node.role === 'statictext' && node.name) {
+      let echoedByParent = false
+      for (let j = i - 1; j >= 0; j--) {
+        if (nodes[j].depth < node.depth) {
+          if (
+            INTERACTIVE_ROLES.has(nodes[j].role) &&
+            nodes[j].name &&
+            nodes[j].name.includes(node.name)
+          ) {
+            echoedByParent = true
+          }
+          break
+        }
+      }
+      if (echoedByParent) {
+        continue
+      }
+    }
+
+    const tagName = isInteractive && node.selector
+      ? extractTagFromSelector(node.selector, node.role)
+      : node.role
+
+    result.push({
+      role: node.role,
+      name: node.name,
+      selector: node.selector,
+      depth: node.depth,
+      isInteractive,
+      tagName,
+      level: node.level || undefined
+    })
+  }
+
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Mobile adapter — JSONElement tree → SnapshotNode[]
+// ---------------------------------------------------------------------------
+
+export function jsonElementToSnapshotNodes(
+  root: JSONElement,
+  platform: 'android' | 'ios',
+  options?: {
+    inViewportOnly?: boolean
+    viewport?: { width: number; height: number }
+    sourceXML?: string
+  }
+): SnapshotNode[] {
+  const { inViewportOnly = true } = options ?? {}
+  const effectiveViewport = options?.viewport ?? { width: 9999, height: 9999 }
+  const automationName = platform === 'android' ? 'uiautomator2' : 'xcuitest'
+
+  const mobileNodes: MobileFlatNode[] = []
+  collectMobileNodes(root, platform, 0, mobileNodes, {
+    inViewportOnly,
+    viewport: effectiveViewport,
+    sourceXML: options?.sourceXML,
+    automationName: options?.sourceXML ? automationName : undefined
+  })
+
+  suppressTagOnlyChildren(mobileNodes)
+
+  return mobileNodes.map((m) => ({
+    role: m.role,
+    name: m.name,
+    selector: m.selector,
+    depth: m.depth,
+    isInteractive: m.isInteractive,
+    tagName: m.tagName,
+    level: undefined
+  }))
 }

--- a/packages/core/src/element-types.ts
+++ b/packages/core/src/element-types.ts
@@ -43,3 +43,32 @@ export interface GetBrowserElementsOptions {
 // Re-export mobile types from locators for convenience.
 // Downstream consumers can also import directly from @wdio/devtools-core/locators.
 export type { JSONElement } from './locators/types.js'
+
+/**
+ * Flat intermediate node shared by both web and mobile snapshot pipelines.
+ * Both adapters (web: AccessibilityNode[], mobile: JSONElement tree) convert
+ * to this shape before buildSnapshot() renders them.
+ */
+export interface SnapshotNode {
+  role: string
+  name: string
+  selector: string
+  depth: number
+  isInteractive: boolean
+  tagName: string
+  level?: number | string
+}
+
+/** Entry in the elements map returned by getSnapshot(). */
+export interface SnapshotElement {
+  selector: string
+  tagName: string
+  role: string
+  text: string
+}
+
+/** Return type of getSnapshot(). */
+export interface SnapshotResult {
+  text: string
+  elements: Record<string, SnapshotElement>
+}

--- a/packages/core/src/element-types.ts
+++ b/packages/core/src/element-types.ts
@@ -61,7 +61,10 @@ export interface SnapshotNode {
 
 /** Entry in the elements map returned by getSnapshot(). */
 export interface SnapshotElement {
+  /** Raw selector — may need .instance(N) on mobile when duplicates exist. */
   selector: string
+  /** Selector with .instance(N) suffix — only set when it differs from `selector` (duplicate disambiguation). */
+  qualifiedSelector?: string
   tagName: string
   role: string
   text: string

--- a/packages/elements/src/get-snapshot.ts
+++ b/packages/elements/src/get-snapshot.ts
@@ -97,13 +97,18 @@ async function getMobileSnapshot(
     return { text: '[No elements found]', elements: {} }
   }
 
+  // A zero-dimension viewport (minimized app, broken ADB connection) would
+  // silently clip every element. Treat it as unavailable instead.
+  const safeViewport =
+    viewportSize?.width && viewportSize?.height ? viewportSize : undefined
+
   const deviceName = getDeviceName(browser)
 
-  const header = buildMobileHeader(platform, deviceName, viewportSize)
+  const header = buildMobileHeader(platform, deviceName, safeViewport)
 
   const snapshotNodes = jsonElementToSnapshotNodes(root, platform, {
     inViewportOnly,
-    viewport: viewportSize ?? undefined,
+    viewport: safeViewport,
     sourceXML: pageSource
   })
 

--- a/packages/elements/src/get-snapshot.ts
+++ b/packages/elements/src/get-snapshot.ts
@@ -1,0 +1,150 @@
+/**
+ * Unified getSnapshot() — single call for web and mobile.
+ *
+ * Auto-detects platform, fetches the accessibility tree (web) or page source
+ * (mobile), converts to a flat SnapshotNode[], and renders a text tree with
+ * e1, e2, … virtual IDs baked in plus an elements map for direct selector
+ * resolution.
+ */
+
+import type { SnapshotResult } from '@wdio/devtools-core/element-types'
+import {
+  buildSnapshot,
+  accessibilityNodesToSnapshotNodes,
+  jsonElementToSnapshotNodes
+} from '@wdio/devtools-core/element-snapshot'
+import { getBrowserAccessibilityTree } from './accessibility-tree.js'
+import { xmlToJSON } from './locators/index.js'
+
+export interface GetSnapshotOptions {
+  /** Only include elements whose bounds intersect the viewport (default true). */
+  inViewportOnly?: boolean
+}
+
+/**
+ * Take a snapshot of the current page/app state.
+ *
+ * Returns a text tree with eN virtual IDs for every interactive element
+ * and an elements map so consumers can resolve e1, e2, … to real selectors
+ * without any post-processing.
+ */
+export async function getSnapshot(
+  browser: WebdriverIO.Browser,
+  options?: GetSnapshotOptions
+): Promise<SnapshotResult> {
+  const { inViewportOnly = true } = options ?? {}
+
+  if (browser.isAndroid || browser.isIOS) {
+    return getMobileSnapshot(browser, inViewportOnly)
+  }
+  return getWebSnapshot(browser, inViewportOnly)
+}
+
+// ---------------------------------------------------------------------------
+// Web
+// ---------------------------------------------------------------------------
+
+async function getWebSnapshot(
+  browser: WebdriverIO.Browser,
+  inViewportOnly: boolean
+): Promise<SnapshotResult> {
+  const [url, title, nodes] = await Promise.all([
+    safeCall(() => browser.getUrl()),
+    safeCall(() => browser.getTitle()),
+    getBrowserAccessibilityTree(browser, { inViewportOnly })
+  ])
+
+  const header = buildWebHeader(title, url)
+  const snapshotNodes = accessibilityNodesToSnapshotNodes(nodes, {
+    inViewportOnly
+  })
+  return buildSnapshot(header, snapshotNodes)
+}
+
+function buildWebHeader(title?: string, url?: string): string {
+  let h = '[Page'
+  if (title) {
+    h += `: ${title}`
+  }
+  if (url) {
+    h += ` — ${url}`
+  }
+  h += ']'
+  return h
+}
+
+// ---------------------------------------------------------------------------
+// Mobile
+// ---------------------------------------------------------------------------
+
+async function getMobileSnapshot(
+  browser: WebdriverIO.Browser,
+  inViewportOnly: boolean
+): Promise<SnapshotResult> {
+  const platform: 'android' | 'ios' = browser.isAndroid ? 'android' : 'ios'
+
+  const [viewportSize, pageSource] = await Promise.all([
+    safeCall(() => browser.getWindowSize()),
+    safeCall(() => browser.getPageSource())
+  ])
+
+  if (!pageSource) {
+    return { text: '[No elements found]', elements: {} }
+  }
+
+  const root = xmlToJSON(pageSource)
+  if (!root) {
+    return { text: '[No elements found]', elements: {} }
+  }
+
+  const deviceName = getDeviceName(browser)
+
+  const header = buildMobileHeader(platform, deviceName, viewportSize)
+
+  const snapshotNodes = jsonElementToSnapshotNodes(root, platform, {
+    inViewportOnly,
+    viewport: viewportSize ?? undefined,
+    sourceXML: pageSource
+  })
+
+  return buildSnapshot(header, snapshotNodes)
+}
+
+function buildMobileHeader(
+  platform: string,
+  deviceName: string,
+  viewport?: { width: number; height: number }
+): string {
+  let h = `[${platform}`
+  if (deviceName) {
+    h += ` — ${deviceName}`
+  }
+  if (viewport) {
+    h += ` (${viewport.width}×${viewport.height})`
+  }
+  h += ']'
+  return h
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function safeCall<T>(fn: () => Promise<T>): Promise<T | undefined> {
+  try {
+    return await fn()
+  } catch {
+    return undefined
+  }
+}
+
+function getDeviceName(browser: WebdriverIO.Browser): string {
+  try {
+    const caps = browser.capabilities as Record<string, unknown>
+    return (
+      (caps['appium:deviceName'] as string) ?? (caps.deviceName as string) ?? ''
+    )
+  } catch {
+    return ''
+  }
+}

--- a/packages/elements/src/index.ts
+++ b/packages/elements/src/index.ts
@@ -23,3 +23,7 @@ export type { VisibleElementsResult } from './get-elements.js'
 export { serializeWebSnapshot, serializeMobileSnapshot } from './snapshot.js'
 export type { WebSnapshotOptions, MobileSnapshotOptions } from './snapshot.js'
 export type { JSONElement } from './locators/index.js'
+
+export { getSnapshot } from './get-snapshot.js'
+export type { GetSnapshotOptions } from './get-snapshot.js'
+export type { SnapshotResult, SnapshotElement } from './snapshot.js'

--- a/packages/elements/src/snapshot.ts
+++ b/packages/elements/src/snapshot.ts
@@ -4,9 +4,17 @@
 
 export {
   serializeWebSnapshot,
-  serializeMobileSnapshot
+  serializeMobileSnapshot,
+  buildSnapshot,
+  accessibilityNodesToSnapshotNodes,
+  jsonElementToSnapshotNodes
 } from '@wdio/devtools-core/element-snapshot'
 export type {
   WebSnapshotOptions,
   MobileSnapshotOptions
 } from '@wdio/devtools-core/element-snapshot'
+export type {
+  SnapshotNode,
+  SnapshotElement,
+  SnapshotResult
+} from '@wdio/devtools-core/element-types'

--- a/packages/elements/tests/snapshot.test.ts
+++ b/packages/elements/tests/snapshot.test.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect } from 'vitest'
 import {
   serializeWebSnapshot,
-  serializeMobileSnapshot
+  serializeMobileSnapshot,
+  buildSnapshot,
+  accessibilityNodesToSnapshotNodes,
+  jsonElementToSnapshotNodes
 } from '../src/snapshot.js'
 import type { AccessibilityNode } from '../src/accessibility-tree.js'
 import type { JSONElement } from '../src/locators/types.js'
+import type { SnapshotNode } from '@wdio/devtools-core/element-types'
 
 // ---------------------------------------------------------------------------
 // serializeWebSnapshot
@@ -246,5 +250,429 @@ describe('serializeMobileSnapshot', () => {
     const out = serializeMobileSnapshot(root, { platform: 'android' })
     expect(out).toContain('FrameLayout')
     expect(out).not.toContain('→')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildSnapshot
+// ---------------------------------------------------------------------------
+
+function snapNode(overrides: Partial<SnapshotNode>): SnapshotNode {
+  return {
+    role: 'button',
+    name: '',
+    selector: '',
+    depth: 0,
+    isInteractive: false,
+    tagName: 'button',
+    ...overrides
+  }
+}
+
+describe('buildSnapshot', () => {
+  it('returns empty elements map for empty nodes', () => {
+    const result = buildSnapshot('[Page]', [])
+    expect(result.text).toBe('[Page]')
+    expect(result.elements).toEqual({})
+  })
+
+  it('renders structural nodes without eN IDs', () => {
+    const nodes = [
+      snapNode({
+        role: 'navigation',
+        depth: 0,
+        name: 'Main',
+        isInteractive: false,
+        tagName: 'nav'
+      })
+    ]
+    const result = buildSnapshot('[Page]', nodes)
+    expect(result.text).toContain('navigation "Main"')
+    expect(result.text).not.toContain('e1')
+    expect(result.text).not.toContain('→')
+    expect(result.elements).toEqual({})
+  })
+
+  it('assigns e1 to first interactive element', () => {
+    const nodes = [
+      snapNode({
+        role: 'button',
+        depth: 0,
+        name: 'Submit',
+        selector: 'button*=Submit',
+        isInteractive: true,
+        tagName: 'button'
+      })
+    ]
+    const result = buildSnapshot('[Page]', nodes)
+    expect(result.text).toContain('e1  button "Submit"  →  button*=Submit')
+    expect(result.elements).toEqual({
+      e1: {
+        selector: 'button*=Submit',
+        tagName: 'button',
+        role: 'button',
+        text: 'Submit'
+      }
+    })
+  })
+
+  it('skips eN for non-interactive nodes and continues numbering', () => {
+    const nodes = [
+      snapNode({
+        role: 'navigation',
+        depth: 0,
+        name: 'Nav',
+        isInteractive: false,
+        tagName: 'nav'
+      }),
+      snapNode({
+        role: 'link',
+        depth: 1,
+        name: 'Home',
+        selector: 'a*=Home',
+        isInteractive: true,
+        tagName: 'a'
+      }),
+      snapNode({
+        role: 'button',
+        depth: 0,
+        name: 'Submit',
+        selector: 'button*=Submit',
+        isInteractive: true,
+        tagName: 'button'
+      })
+    ]
+    const result = buildSnapshot('[Page]', nodes)
+    expect(result.text).toContain('navigation "Nav"')
+    // link at depth 1 has "Nav" as its structural ancestor → ∈ context
+    expect(result.text).toContain('e1  link "Home" ∈ "Nav"  →  a*=Home')
+    // button at depth 0 also gets ∈ "Nav" — Nav is a same-depth structural sibling
+    expect(result.text).toContain(
+      'e2  button "Submit" ∈ "Nav"  →  button*=Submit'
+    )
+    expect(Object.keys(result.elements)).toEqual(['e1', 'e2'])
+  })
+
+  it('renders heading with level suffix', () => {
+    const nodes = [
+      snapNode({
+        role: 'heading',
+        depth: 0,
+        name: 'Welcome',
+        level: 2,
+        isInteractive: false,
+        tagName: 'h2'
+      })
+    ]
+    const result = buildSnapshot('[Page]', nodes)
+    expect(result.text).toContain('heading[2] "Welcome"')
+  })
+
+  it('renders ∈ ancestor context for interactive nodes', () => {
+    const nodes = [
+      snapNode({
+        role: 'form',
+        depth: 0,
+        name: 'Login',
+        isInteractive: false,
+        tagName: 'form'
+      }),
+      snapNode({
+        role: 'textbox',
+        depth: 1,
+        name: 'Email',
+        selector: '#email',
+        isInteractive: true,
+        tagName: 'input'
+      })
+    ]
+    const result = buildSnapshot('[Page]', nodes)
+    expect(result.text).toContain('e1  textbox "Email" ∈ "Login"  →  #email')
+  })
+
+  it('omits ∈ context when same-depth sibling is interactive', () => {
+    const nodes = [
+      snapNode({
+        role: 'button',
+        depth: 0,
+        name: 'Cancel',
+        selector: 'button*=Cancel',
+        isInteractive: true,
+        tagName: 'button'
+      }),
+      snapNode({
+        role: 'button',
+        depth: 0,
+        name: 'Submit',
+        selector: 'button*=Submit',
+        isInteractive: true,
+        tagName: 'button'
+      })
+    ]
+    const result = buildSnapshot('[Page]', nodes)
+    // Second button should NOT have ∈ "Cancel" context (same-depth interactive isn't context)
+    expect(result.text).toContain('e2  button "Submit"  →  button*=Submit')
+    expect(result.text).not.toContain('∈ "Cancel"')
+  })
+
+  it('appends .instance(N) for duplicate selectors', () => {
+    const nodes = [
+      snapNode({
+        role: 'button',
+        depth: 0,
+        name: 'Add',
+        selector: 'button*=Add',
+        isInteractive: true,
+        tagName: 'button'
+      }),
+      snapNode({
+        role: 'button',
+        depth: 0,
+        name: 'Add',
+        selector: 'button*=Add',
+        isInteractive: true,
+        tagName: 'button'
+      })
+    ]
+    const result = buildSnapshot('[Page]', nodes)
+    expect(result.text).toContain('button*=Add.instance(0)')
+    expect(result.text).toContain('button*=Add.instance(1)')
+    // Elements map stores the raw selector without .instance(N)
+    expect(result.elements['e1']!.selector).toBe('button*=Add')
+    expect(result.elements['e2']!.selector).toBe('button*=Add')
+  })
+
+  it('handles interactive node with no name but context ancestor', () => {
+    const nodes = [
+      snapNode({
+        role: 'form',
+        depth: 0,
+        name: 'Search',
+        isInteractive: false,
+        tagName: 'form'
+      }),
+      snapNode({
+        role: 'textbox',
+        depth: 1,
+        name: '',
+        selector: '#q',
+        isInteractive: true,
+        tagName: 'input'
+      })
+    ]
+    const result = buildSnapshot('[Page]', nodes)
+    expect(result.text).toContain('e1  textbox ∈ "Search"  →  #q')
+    expect(result.elements['e1']!.text).toBe('')
+  })
+
+  it('indents according to depth', () => {
+    const nodes = [
+      snapNode({
+        role: 'main',
+        depth: 0,
+        name: '',
+        isInteractive: false,
+        tagName: 'main'
+      }),
+      snapNode({
+        role: 'button',
+        depth: 1,
+        name: 'Click',
+        selector: '#btn',
+        isInteractive: true,
+        tagName: 'button'
+      })
+    ]
+    const lines = buildSnapshot('[Page]', nodes).text.split('\n')
+    expect(lines[1]).toMatch(/^  main/)
+    expect(lines[2]).toMatch(/^    e1/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// accessibilityNodesToSnapshotNodes
+// ---------------------------------------------------------------------------
+
+describe('accessibilityNodesToSnapshotNodes', () => {
+  it('converts interactive node and derives tagName from selector', () => {
+    const input = [
+      node({
+        role: 'button',
+        depth: 0,
+        name: 'Submit',
+        selector: 'button*=Submit'
+      })
+    ]
+    const result = accessibilityNodesToSnapshotNodes(input)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      role: 'button',
+      name: 'Submit',
+      selector: 'button*=Submit',
+      isInteractive: true,
+      tagName: 'button'
+    })
+  })
+
+  it('filters out off-screen nodes when inViewportOnly is true', () => {
+    const input = [
+      node({
+        role: 'button',
+        depth: 0,
+        name: 'Submit',
+        selector: 'button*=Submit',
+        isInViewport: false
+      })
+    ]
+    const result = accessibilityNodesToSnapshotNodes(input, {
+      inViewportOnly: true
+    })
+    expect(result).toHaveLength(0)
+  })
+
+  it('keeps off-screen nodes when inViewportOnly is false', () => {
+    const input = [
+      node({
+        role: 'button',
+        depth: 0,
+        name: 'Submit',
+        selector: 'button*=Submit',
+        isInViewport: false
+      })
+    ]
+    const result = accessibilityNodesToSnapshotNodes(input, {
+      inViewportOnly: false
+    })
+    expect(result).toHaveLength(1)
+  })
+
+  it('sets isInteractive false for structural roles', () => {
+    const input = [node({ role: 'navigation', depth: 0, name: 'Nav' })]
+    const result = accessibilityNodesToSnapshotNodes(input)
+    expect(result[0]!.isInteractive).toBe(false)
+    expect(result[0]!.tagName).toBe('navigation') // fallback to role
+  })
+
+  it('suppresses statictext echoed by interactive parent', () => {
+    const input = [
+      node({
+        role: 'button',
+        depth: 0,
+        name: 'Submit',
+        selector: 'button*=Submit'
+      }),
+      node({ role: 'statictext', depth: 1, name: 'Submit' })
+    ]
+    const result = accessibilityNodesToSnapshotNodes(input)
+    expect(result).toHaveLength(1) // statictext suppressed
+    expect(result[0]!.role).toBe('button')
+  })
+
+  it('derives tagName from link selector', () => {
+    const input = [
+      node({ role: 'link', depth: 0, name: 'Home', selector: 'a*=Home' })
+    ]
+    const result = accessibilityNodesToSnapshotNodes(input)
+    expect(result[0]!.tagName).toBe('a')
+  })
+
+  it('falls back to role for selectorless tag extraction', () => {
+    const input = [
+      node({ role: 'textbox', depth: 0, name: 'Email', selector: '#email' })
+    ]
+    const result = accessibilityNodesToSnapshotNodes(input)
+    // #email doesn't start with a tag prefix → falls back to role
+    expect(result[0]!.tagName).toBe('textbox')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// jsonElementToSnapshotNodes
+// ---------------------------------------------------------------------------
+
+describe('jsonElementToSnapshotNodes', () => {
+  it('flattens a simple tree', () => {
+    const root = mobileEl('hierarchy', {}, [
+      mobileEl('android.widget.Button', {
+        clickable: 'true',
+        'content-desc': 'Submit',
+        text: ''
+      })
+    ])
+    const result = jsonElementToSnapshotNodes(root, 'android')
+    // Root hierarchy element + one button = 2 nodes
+    expect(result.length).toBeGreaterThanOrEqual(2)
+    const button = result.find((n) => n.role === 'button')
+    expect(button).toBeDefined()
+    expect(button).toMatchObject({
+      role: 'button',
+      name: 'Submit',
+      isInteractive: true,
+      tagName: 'android.widget.Button'
+    })
+  })
+
+  it('includes structural containers', () => {
+    const root = mobileEl('hierarchy', {}, [
+      mobileEl(
+        'android.widget.LinearLayout',
+        {
+          'content-desc': ''
+        },
+        [
+          mobileEl('android.widget.Button', {
+            clickable: 'true',
+            'content-desc': 'OK',
+            text: ''
+          })
+        ]
+      )
+    ])
+    const result = jsonElementToSnapshotNodes(root, 'android')
+    // LinearLayout is not in INTERACTIVE_ROLES, not clickable → structural
+    expect(result.length).toBeGreaterThanOrEqual(2)
+    const structNode = result.find((n) => n.role === 'LinearLayout')
+    expect(structNode).toBeDefined()
+    expect(structNode!.isInteractive).toBe(false)
+  })
+
+  it('suppresses tag-only-interactive children of explicit parents', () => {
+    const root = mobileEl('hierarchy', {}, [
+      mobileEl(
+        'android.widget.LinearLayout',
+        {
+          clickable: 'true',
+          'content-desc': 'Row'
+        },
+        [
+          // TextView is in ANDROID_INTERACTABLE_TAGS (tag-interactive),
+          // but not explicitly clickable → suppressed by suppressTagOnlyChildren
+          mobileEl('android.widget.TextView', {
+            clickable: 'false',
+            'content-desc': '',
+            text: 'Label'
+          })
+        ]
+      )
+    ])
+    const result = jsonElementToSnapshotNodes(root, 'android')
+    const textView = result.find((n) => n.role === 'statictext')
+    expect(textView).toBeDefined()
+    expect(textView!.isInteractive).toBe(false) // suppressed
+  })
+
+  it('propagates tagName from the mobile element', () => {
+    const root = mobileEl('hierarchy', {}, [
+      mobileEl('android.widget.EditText', {
+        clickable: 'true',
+        'content-desc': '',
+        'resource-id': 'com.example:id/email',
+        text: ''
+      })
+    ])
+    const result = jsonElementToSnapshotNodes(root, 'android')
+    const editText = result.find((n) => n.role === 'textbox')
+    expect(editText).toBeDefined()
+    expect(editText!.tagName).toBe('android.widget.EditText')
   })
 })

--- a/packages/service/src/index.ts
+++ b/packages/service/src/index.ts
@@ -173,6 +173,18 @@ export default class DevToolsHookService implements Services.ServiceInstance {
           })
         )
     }
+
+    /**
+     * Runtime DOM snapshot for agent auto-healing loops. Calls into
+     * @wdio/elements' getSnapshot() directly — no trace-mode overhead,
+     * no screenshot round-trip, no page-settling.
+     *
+     * Returns { text, elements } — see @wdio/elements SnapshotResult.
+     */
+    browser.addCommand('getSnapshot', async (options?: { inViewportOnly?: boolean }) => {
+      const { getSnapshot } = await import('@wdio/elements')
+      return getSnapshot(browser, options ?? { inViewportOnly: true })
+    })
   }
 
   // The method signature is corrected to use W3CCapabilities

--- a/packages/service/src/index.ts
+++ b/packages/service/src/index.ts
@@ -182,8 +182,13 @@ export default class DevToolsHookService implements Services.ServiceInstance {
      * Returns { text, elements } — see @wdio/elements SnapshotResult.
      */
     browser.addCommand('getSnapshot', async (options?: { inViewportOnly?: boolean }) => {
-      const { getSnapshot } = await import('@wdio/elements')
-      return getSnapshot(browser, options ?? { inViewportOnly: true })
+      try {
+        const { getSnapshot } = await import('@wdio/elements')
+        return await getSnapshot(browser, options ?? { inViewportOnly: true })
+      } catch (err) {
+        log.warn(`getSnapshot failed: ${errorMessage(err)}`)
+        return { text: '[Snapshot unavailable]', elements: {} }
+      }
     })
   }
 

--- a/packages/service/src/types.ts
+++ b/packages/service/src/types.ts
@@ -4,6 +4,8 @@
 // @wdio/devtools-service/types. New code should import directly from
 // @wdio/devtools-shared.
 
+import type { SnapshotResult } from '@wdio/devtools-core/element-types'
+
 export {
   TraceType,
   type CommandLog,
@@ -90,6 +92,9 @@ declare namespace WebdriverIO {
     getPuppeteer?: () => Promise<unknown>
     // BiDi-specific WDIO method, present at runtime when BiDi is active.
     sessionSubscribe?: (opts: { events: string[] }) => Promise<unknown>
+    // Runtime DOM snapshot for agent auto-healing. Added by
+    // @wdio/devtools-service in the before hook.
+    getSnapshot(options?: { inViewportOnly?: boolean }): Promise<SnapshotResult>
   }
 }
 

--- a/packages/service/tests/index.test.ts
+++ b/packages/service/tests/index.test.ts
@@ -74,6 +74,7 @@ describe('DevtoolsService - Internal Command Filtering', () => {
   const mockBrowser = {
     isBidi: true,
     sessionId: 'test-session',
+    addCommand: vi.fn(),
     scriptAddPreloadScript: vi.fn().mockResolvedValue(undefined),
     takeScreenshot: vi.fn().mockResolvedValue('screenshot'),
     execute: vi.fn().mockResolvedValue({
@@ -175,6 +176,7 @@ describe('DevtoolsService - Screencast Integration', () => {
   const mockBrowser = {
     isBidi: true,
     sessionId: 'session-123',
+    addCommand: vi.fn(),
     scriptAddPreloadScript: vi.fn().mockResolvedValue(undefined),
     takeScreenshot: vi.fn().mockResolvedValue('screenshot'),
     execute: vi.fn().mockResolvedValue({


### PR DESCRIPTION
## What & why

[//]: # (What does this PR change, and what problem does it solve? Link the issue it closes, if any.)

Adds a unified `getSnapshot()` to `@wdio/elements` that returns an AI-readable DOM tree with embedded `e1`, `e2`, … virtual element IDs plus an elements map for direct selector resolution — no post-processing required.

**Before** (the harness at `wdio-agent-harness`): consumer had to call three separate APIs (`getInteractableBrowserElements / getMobileVisibleElements`, `serializeWebSnapshot / serializeMobileSnapshot`, `buildToonWithIds`), maintain a `VirtualIdMapper` instance, and stitch virtual IDs into text externally.

**After**: single call → `{ text, elements }`. Auto-detects web vs mobile. Same return type for both platforms.

Also wires a thin `browser.getSnapshot()` runtime accessor in the WDIO service — zero trace-mode overhead, no screenshot round-trip.

## Type of change

[//]: # (Put an `x` in the boxes that apply.)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Polish (an improvement to an existing feature)
- [ ] Breaking change (existing behavior changes for users)
- [ ] Documentation
- [ ] Internal (build, CI, dependencies, tooling)

## Packages touched

[//]: # (DevTools is a monorepo — checking these helps reviewers know where to look.)

- [ ] `shared` (types and contracts)
- [x] `core` (framework-agnostic capture/reporting)
- [x] `service` (WebdriverIO adapter)
- [x] `elements`
- [ ] `nightwatch-devtools` (Nightwatch adapter)
- [ ] `selenium-devtools` (Selenium adapter)
- [ ] `backend` (server)
- [ ] `app` (UI)
- [ ] `script` (page-injected runtime)

## Notes for reviewers

  - **Entirely additive** — all existing exports (`serializeWebSnapshot`, `serializeMobileSnapshot`, `getInteractableBrowserElements`, `getElements`, etc.) are unchanged.
  - **Two snapshot pipelines coexist**: `serializeWebSnapshot` (trace mode, visual replay) and `buildSnapshot` (runtime, agent loops). The shared `isStatictextEchoedByParent()` helper ensures the statictext dedup logic stays in sync.
  - **`.instance(N)` disambiguation**: stored as `qualifiedSelector` on `SnapshotElement` when duplicates exist. Raw `selector` stays — consumers use `qualifiedSelector` to target a specific duplicate.
  - **`tagName` on `MobileFlatNode`**: additive field, internal only — no downstream breakage.
  - **21 new tests** in `snapshot.test.ts` covering `buildSnapshot()`, both adapters, statictext dedup, `.instance(N)`, ∈ context, viewport filtering.

## Verification

  - `pnpm test` — 44 pass in `@wdio/elements` (23 existing + 21 new), 133 pass in `@wdio/devtools-core`
  - `pnpm build` — clean for `@wdio/elements`, `@wdio/devtools-service`, `@wdio/devtools-core`
  - Manual — `examples/wdio/features/snapshot.feature` exercises `getSnapshot()` headlessly against the-internet.herokuapp.com. Trace mode (`wdio.trace.conf.ts`) verified snapshots appear in `trace.zip` resources.
