### PR TITLE
fix(ci): Auto-bump published dependents when private packages change,…

### DIFF
--- a/.changeset/1784563347-7324-0094.md
+++ b/.changeset/1784563347-7324-0094.md
@@ -1,0 +1,5 @@
+---
+"@wdio/nightwatch-devtools": patch
+---
+
+- Bump @wdio/devtools-core to 1.0.1

--- a/.changeset/1784563347-7324-0965.md
+++ b/.changeset/1784563347-7324-0965.md
@@ -1,0 +1,5 @@
+---
+"@wdio/devtools-service": patch
+---
+
+- Bump @wdio/devtools-core to 1.0.1

--- a/.changeset/1784563347-7324-6c9f.md
+++ b/.changeset/1784563347-7324-6c9f.md
@@ -1,0 +1,5 @@
+---
+"@wdio/selenium-devtools": patch
+---
+
+- Bump @wdio/devtools-core to 1.0.1

--- a/.changeset/1784563347-7324-df46.md
+++ b/.changeset/1784563347-7324-df46.md
@@ -1,0 +1,5 @@
+---
+"@wdio/elements": patch
+---
+
+- Bump @wdio/devtools-core to 1.0.1

--- a/.changeset/changeset-gen.sh
+++ b/.changeset/changeset-gen.sh
@@ -108,3 +108,39 @@ echo "✅ $OUT  (bump: $BUMP, scope: $PKG_DIR)"
 echo ""
 echo "--- Preview ---"
 cat "$OUT"
+
+# ---- If package is private, bump all published dependents ----
+IS_PRIVATE=$(jq -r '.private // false' "$PKG_DIR/package.json")
+if [ "$IS_PRIVATE" = "true" ]; then
+  echo ""
+  echo "📦 $PACKAGE is private — bumping published dependents..."
+
+  DEP_IDX=0
+  for f in packages/*/package.json; do
+    CONSUMER_NAME=$(jq -r '.name' "$f")
+    CONSUMER_PRIVATE=$(jq -r '.private // false' "$f")
+
+    [ "$CONSUMER_NAME" = "$PACKAGE" ] && continue
+    [ "$CONSUMER_PRIVATE" = "true" ] && continue
+
+    if grep -q "\"$PACKAGE\"" "$f" 2>/dev/null; then
+      DEP_IDX=$((DEP_IDX + 1))
+      echo "  → $CONSUMER_NAME (patch)"
+
+      DEP_SLUG=$(date +%s)-$(($$ % 10000))-$DEP_IDX-$(openssl rand -hex 2 2>/dev/null || echo "$RANDOM")
+      DEP_OUT=".changeset/$DEP_SLUG.md"
+
+      {
+        echo "---"
+        echo "\"$CONSUMER_NAME\": patch"
+        echo "---"
+        echo ""
+        echo "- Bump $PACKAGE dependency"
+      } > "$DEP_OUT"
+
+      echo "✅ $DEP_OUT"
+    fi
+  done
+
+  [ "$DEP_IDX" -eq 0 ] && echo "  (no published dependents found)"
+fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,19 @@ jobs:
 
           # Bump the monorepo root version so tags always advance.
           # The root is private (never published) and drives the v* tag.
-          npm version minor --no-git-tag-version
-          git commit --amend --no-edit
+          CURRENT=$(jq -r '.version' package.json)
+          MAJOR=$(echo "$CURRENT" | cut -d. -f1)
+          MINOR=$(echo "$CURRENT" | cut -d. -f2)
+          NEW="$MAJOR.$((MINOR + 1)).0"
+          jq ".version = \"$NEW\"" package.json > package.json.tmp && mv package.json.tmp package.json
+          git add package.json
+
+          # Squash into the changeset commit if one was created, otherwise commit standalone.
+          if git log -1 --format='%s' | grep -q '^RELEASING:'; then
+            git commit --amend --no-edit
+          else
+            git commit -m "v$NEW"
+          fi
 
       - name: Publish
         env:
@@ -63,8 +74,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="v$(jq -r '.version' package.json)"
-          git tag "$TAG"
-          git push origin "$TAG"
+          git tag -f "$TAG"
+          git push --force origin "$TAG"
           gh release create "$TAG" \
             --title "$TAG" \
             --generate-notes \


### PR DESCRIPTION
… fix release workflow version squashing and tag collision

- changeset-gen.sh: detect private packages, auto-generate patch changesets for all published consumers
- release.yml: replace npm version minor with manual jq bump that squashes into changeset commit
- release.yml: force-overwrite tags on retry to handle failed-release recovery
- Add patch changesets for 4 consumers to pick up @wdio/devtools-core@1.0.1

## What & why

[//]: # (What does this PR change, and what problem does it solve? Link the issue it closes, if any.)

## Type of change

[//]: # (Put an `x` in the boxes that apply.)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Polish (an improvement to an existing feature)
- [ ] Breaking change (existing behavior changes for users)
- [ ] Documentation
- [x] Internal (build, CI, dependencies, tooling)

## Packages touched

[//]: # (DevTools is a monorepo — checking these helps reviewers know where to look.)

- [ ] `shared` (types and contracts)
- [ ] `core` (framework-agnostic capture/reporting)
- [x] `service` (WebdriverIO adapter)
- [x] `nightwatch-devtools` (Nightwatch adapter)
- [x] `selenium-devtools` (Selenium adapter)
- [ ] `backend` (server)
- [ ] `app` (UI)
- [ ] `script` (page-injected runtime)

## Notes for reviewers

[//]: # (Anything non-obvious: design trade-offs, alternatives you ruled out, follow-ups. If this PR touches more than one adapter, say why the shared logic doesn't live in `core`.)

## Screenshots / recordings

[//]: # (Required for UI changes — before/after images or a short clip.)
