### PR TITLE
fix(ci): Add `releaseType` parameter for monorepo root version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,15 @@ on:
         required: false
         type: string
         default: 'latest'
+      releaseType:
+        description: 'Release type for monorepo root (drives the v* tag)'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: 'patch'
 
 env:
   NPM_CONFIG_PROVENANCE: true
@@ -40,24 +49,7 @@ jobs:
       - name: Build
         run: pnpm -r build
       - name: Consume changesets
-        run: |
-          npx changeset version
-
-          # Bump the monorepo root version so tags always advance.
-          # The root is private (never published) and drives the v* tag.
-          CURRENT=$(jq -r '.version' package.json)
-          MAJOR=$(echo "$CURRENT" | cut -d. -f1)
-          MINOR=$(echo "$CURRENT" | cut -d. -f2)
-          NEW="$MAJOR.$((MINOR + 1)).0"
-          jq ".version = \"$NEW\"" package.json > package.json.tmp && mv package.json.tmp package.json
-          git add package.json
-
-          # Squash into the changeset commit if one was created, otherwise commit standalone.
-          if git log -1 --format='%s' | grep -q '^RELEASING:'; then
-            git commit --amend --no-edit
-          else
-            git commit -m "v$NEW"
-          fi
+        run: npx changeset version
 
       - name: Publish
         env:
@@ -66,16 +58,13 @@ jobs:
           DIST_TAG: ${{ inputs.distTag }}
         run: npx changeset publish --tag "${DIST_TAG}" --no-git-tag
 
-      - name: Push version commit
-        run: git push origin main
-
       - name: GitHub Release & Tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG="v$(jq -r '.version' package.json)"
-          git tag -f "$TAG"
-          git push --force origin "$TAG"
+          TAG=$(npm version ${{ inputs.releaseType }})
+          git push origin main
+          git push origin "$TAG"
           gh release create "$TAG" \
             --title "$TAG" \
             --generate-notes \


### PR DESCRIPTION
## What & why

[//]: # (What does this PR change, and what problem does it solve? Link the issue it closes, if any.)

## Type of change

[//]: # (Put an `x` in the boxes that apply.)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Polish (an improvement to an existing feature)
- [ ] Breaking change (existing behavior changes for users)
- [ ] Documentation
- [x] Internal (build, CI, dependencies, tooling)

## Packages touched

[//]: # (DevTools is a monorepo — checking these helps reviewers know where to look.)

- [ ] `shared` (types and contracts)
- [ ] `core` (framework-agnostic capture/reporting)
- [ ] `service` (WebdriverIO adapter)
- [ ] `nightwatch-devtools` (Nightwatch adapter)
- [ ] `selenium-devtools` (Selenium adapter)
- [ ] `backend` (server)
- [ ] `app` (UI)
- [ ] `script` (page-injected runtime)

## Notes for reviewers

[//]: # (Anything non-obvious: design trade-offs, alternatives you ruled out, follow-ups. If this PR touches more than one adapter, say why the shared logic doesn't live in `core`.)

## Screenshots / recordings

[//]: # (Required for UI changes — before/after images or a short clip.)
