### PR TITLE
fix(app): keep test-tree and action rows on one line inside their panel

### DIFF
--- a/packages/app/src/components/sidebar.ts
+++ b/packages/app/src/components/sidebar.ts
@@ -21,6 +21,10 @@ export class DevtoolsSidebar extends Element {
         flex-direction: column;
         height: 100%;
         min-height: 0;
+        /* Without this, single-line test names make the automatic minimum
+           width beat the drag handle's flex-basis and the panel outgrows it. */
+        min-width: 0;
+        overflow: hidden;
       }
 
       .top {

--- a/packages/app/src/components/sidebar/explorer.ts
+++ b/packages/app/src/components/sidebar/explorer.ts
@@ -50,6 +50,7 @@ export class DevtoolsSidebarExplorer extends CollapseableEntry {
   #statusFilter: TestStatus | null = null
   #selectedUid?: string
   #autoSelectedUid?: string
+  #revealedUid?: string
   #filterListener = this.#filterTests.bind(this)
   #statusFilterListener = this.#applyStatusFilter.bind(this)
   #selectListener = this.#handleSelect.bind(this)
@@ -141,7 +142,12 @@ export class DevtoolsSidebarExplorer extends CollapseableEntry {
   }
 
   #handleSelect(event: CustomEvent<string>) {
-    this.#selectedUid = event.detail
+    const uid = event.detail
+    // Only one row shows its full name at a time: clicking a row folds whichever
+    // was open, and clicking the open one folds it. The event is click-only, so
+    // the tree auto-selecting the running test never expands anything.
+    this.#revealedUid = uid === this.#revealedUid ? undefined : uid
+    this.#selectedUid = uid
     this.requestUpdate()
   }
 
@@ -376,6 +382,7 @@ export class DevtoolsSidebarExplorer extends CollapseableEntry {
         ?has-children="${entry.children && entry.children.length > 0}"
         ?selected="${entry.uid ===
         (this.#selectedUid ?? this.#autoSelectedUid)}"
+        ?revealed="${entry.uid === this.#revealedUid}"
         ?root="${isRoot}"
         .runDisabled=${this.#isRunDisabled(entry)}
         .runDisabledReason=${this.#getRunDisabledReason(entry)}

--- a/packages/app/src/components/sidebar/explorer.ts
+++ b/packages/app/src/components/sidebar/explorer.ts
@@ -65,6 +65,7 @@ export class DevtoolsSidebarExplorer extends CollapseableEntry {
         display: flex;
         flex-direction: column;
         min-height: 0;
+        min-width: 0;
         flex: 1 1 auto;
       }
 

--- a/packages/app/src/components/sidebar/test-suite.ts
+++ b/packages/app/src/components/sidebar/test-suite.ts
@@ -93,8 +93,9 @@ export class ExplorerTestEntry extends CollapseableEntry {
   @property({ type: Boolean, reflect: true })
   selected = false
 
-  /** Set by a click on this row alone. `selected` can't drive it: the tree
-   *  auto-selects the running test, so it would expand a row nobody touched. */
+  /** Whether this row shows its name in full. Owned by the explorer, which keeps
+   *  exactly one row revealed; `selected` can't drive it because the tree
+   *  auto-selects the running test, expanding a row nobody touched. */
   @property({ type: Boolean, reflect: true })
   revealed = false
 
@@ -209,7 +210,6 @@ export class ExplorerTestEntry extends CollapseableEntry {
   }
 
   #selectEntry() {
-    this.revealed = !this.revealed
     if (this.uid) {
       this.dispatchEvent(
         new CustomEvent('app-test-select', {

--- a/packages/app/src/components/sidebar/test-suite.ts
+++ b/packages/app/src/components/sidebar/test-suite.ts
@@ -93,6 +93,11 @@ export class ExplorerTestEntry extends CollapseableEntry {
   @property({ type: Boolean, reflect: true })
   selected = false
 
+  /** Set by a click on this row alone. `selected` can't drive it: the tree
+   *  auto-selects the running test, so it would expand a row nobody touched. */
+  @property({ type: Boolean, reflect: true })
+  revealed = false
+
   @property({ type: Boolean, reflect: true })
   root = false
 
@@ -110,6 +115,18 @@ export class ExplorerTestEntry extends CollapseableEntry {
         font-size: 12.5px;
         /* matches the icon box height so the icon aligns with the first line */
         line-height: 18px;
+        /* One line per row so every entry in the tree is the same height */
+        display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      /* Clicking a row is the only way to read a name it had to clip. Wrapping
+         anywhere because a name can be one unbroken token (a URL) that plain
+         wrapping would still clip. */
+      :host([revealed]) ::slotted(label) {
+        white-space: normal;
+        overflow-wrap: anywhere;
       }
 
       :host([selected]) .row {
@@ -192,6 +209,7 @@ export class ExplorerTestEntry extends CollapseableEntry {
   }
 
   #selectEntry() {
+    this.revealed = !this.revealed
     if (this.uid) {
       this.dispatchEvent(
         new CustomEvent('app-test-select', {
@@ -426,13 +444,13 @@ export class ExplorerTestEntry extends CollapseableEntry {
           ></icon-mdi-menu-down>
         </button>
         <span
-          class="flex items-start shrink flex-nowrap min-w-0 leading-[18px] ${hasNoChildren
+          class="flex items-start flex-nowrap min-w-0 flex-1 leading-[18px] ${hasNoChildren
             ? 'pl-9'
             : ''}"
           @click="${() => this.#selectEntry()}"
         >
           ${this.root ? nothing : this.testStateIcon}
-          <slot name="label" class="mx-2 block flex-initial shrink"></slot>
+          <slot name="label" class="mx-2 block min-w-0 flex-1"></slot>
         </span>
         ${this.#renderToolbar(hasNoChildren)}
       </section>

--- a/packages/app/src/components/workbench/action-tree.ts
+++ b/packages/app/src/components/workbench/action-tree.ts
@@ -21,6 +21,16 @@ export interface CommandRow {
 
 export type ActionTreeRow = GroupRow | CommandRow
 
+/** Identity of a render row. Rows are keyed on it so an expand/collapse moves
+ *  each element with the action it belongs to; reusing whatever element sat at
+ *  that index hands the new action the old row's local state. Namespaced so a
+ *  callId that reads as a number can't collide with a command index. */
+export function rowKey(row: ActionTreeRow): string {
+  return row.kind === 'group'
+    ? `group:${row.group.callId}`
+    : `command:${row.commandIndex}`
+}
+
 /** Command indices anywhere under a group, nested groups included. */
 export function collectCommandIndices(group: TraceActionGroupNode): number[] {
   const indices: number[] = []

--- a/packages/app/src/components/workbench/actionItems/command.ts
+++ b/packages/app/src/components/workbench/actionItems/command.ts
@@ -50,6 +50,7 @@ export class CommandItem extends ActionItem {
     if (!this.entry) {
       return
     }
+    this.toggleRevealed()
     window.dispatchEvent(
       // Typed as the contract, which is what makes the two nullable fields below
       // a compile error rather than a blank chip in the Log tab.
@@ -117,10 +118,7 @@ export class CommandItem extends ActionItem {
         @click="${() => this.#highlightLine()}"
       >
         ${this.iconChip(this.#renderIcon(entry.command))}
-        <code
-          class="text-[12.5px] flex-wrap text-left break-all ${this.failed
-            ? 'text-chartsRed'
-            : ''}"
+        <code class="label text-[12.5px] ${this.failed ? 'text-chartsRed' : ''}"
           >${capitalizeAssertLabel(entry.title ?? entry.command)}</code
         >
         ${this.renderTime()}

--- a/packages/app/src/components/workbench/actionItems/command.ts
+++ b/packages/app/src/components/workbench/actionItems/command.ts
@@ -50,7 +50,7 @@ export class CommandItem extends ActionItem {
     if (!this.entry) {
       return
     }
-    this.toggleRevealed()
+    this.requestReveal()
     window.dispatchEvent(
       // Typed as the contract, which is what makes the two nullable fields below
       // a compile error rather than a blank chip in the Log tab.

--- a/packages/app/src/components/workbench/actionItems/group.ts
+++ b/packages/app/src/components/workbench/actionItems/group.ts
@@ -26,6 +26,7 @@ export class GroupItem extends ActionItem {
   }
 
   #toggle() {
+    this.toggleRevealed()
     this.dispatchEvent(
       new CustomEvent('group-toggle', {
         detail: { callId: this.group?.callId, expanded: this.expanded },
@@ -51,7 +52,7 @@ export class GroupItem extends ActionItem {
             : ''}"
         ></icon-mdi-chevron-right>
         <span
-          class="text-[12.5px] font-medium text-left break-all ${this.failed
+          class="label text-[12.5px] font-medium ${this.failed
             ? 'text-chartsRed'
             : ''}"
           >${this.group.title}</span

--- a/packages/app/src/components/workbench/actionItems/group.ts
+++ b/packages/app/src/components/workbench/actionItems/group.ts
@@ -26,7 +26,7 @@ export class GroupItem extends ActionItem {
   }
 
   #toggle() {
-    this.toggleRevealed()
+    this.requestReveal()
     this.dispatchEvent(
       new CustomEvent('group-toggle', {
         detail: { callId: this.group?.callId, expanded: this.expanded },

--- a/packages/app/src/components/workbench/actionItems/item.ts
+++ b/packages/app/src/components/workbench/actionItems/item.ts
@@ -33,6 +33,16 @@ export class ActionItem extends Element {
   @property({ type: Boolean, reflect: true })
   failed = false
 
+  /** Set by a click on this row alone. `active` can't drive it: the player
+   *  clock marks the action at the playhead, so it would expand rows nobody
+   *  touched and the panel would look as ragged as before. */
+  @property({ type: Boolean, reflect: true })
+  revealed = false
+
+  protected toggleRevealed() {
+    this.revealed = !this.revealed
+  }
+
   static styles = [
     ...Element.styles,
     css`
@@ -44,6 +54,24 @@ export class ActionItem extends Element {
 
       button {
         position: relative;
+        /* Same height for every row whether or not it carries an icon chip
+           (chip 26px + its 4px margins). */
+        min-height: 34px;
+      }
+
+      /* One line per row; clicking a row is what reflows its full text. */
+      .label {
+        flex: 1 1 auto;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        text-align: left;
+        padding-right: 8px;
+      }
+      :host([revealed]) .label {
+        white-space: normal;
+        overflow-wrap: anywhere;
       }
 
       .ic {
@@ -102,7 +130,7 @@ export class ActionItem extends Element {
     const heatCls = HEAT_CLASS[durationHeat(this.duration)]
     return html`
       <span
-        class="text-[10px] grow-0 shrink rounded-xl ml-auto px-1.5 py-px font-medium ${heatCls}"
+        class="text-[10px] flex-none whitespace-nowrap rounded-xl ml-auto px-1.5 py-px font-medium ${heatCls}"
         >${formatDuration(this.duration)}</span
       >
     `

--- a/packages/app/src/components/workbench/actionItems/item.ts
+++ b/packages/app/src/components/workbench/actionItems/item.ts
@@ -7,6 +7,9 @@ import { formatDuration, durationHeat, type DurationHeat } from './duration.js'
 
 export type ActionEntry = TraceMutation | CommandLog
 
+/** What a row reports as its identity: an action by reference, a group by key. */
+export type RowRevealKey = string | ActionEntry
+
 /** Icon sized to sit inside the `.ic` chip rendered by `iconChip`. */
 export const ICON_CLASS = 'w-[15px] h-[15px] block shrink-0'
 
@@ -33,14 +36,25 @@ export class ActionItem extends Element {
   @property({ type: Boolean, reflect: true })
   failed = false
 
-  /** Set by a click on this row alone. `active` can't drive it: the player
-   *  clock marks the action at the playhead, so it would expand rows nobody
-   *  touched and the panel would look as ragged as before. */
+  /** Whether this row shows its label in full. Owned by the list, which keeps
+   *  exactly one row revealed; `active` can't drive it because the player clock
+   *  marks the action at the playhead, expanding rows nobody touched. */
   @property({ type: Boolean, reflect: true })
   revealed = false
 
-  protected toggleRevealed() {
-    this.revealed = !this.revealed
+  /** Identity this row echoes back on click, for the list to compare. */
+  @property({ attribute: false })
+  revealKey?: RowRevealKey
+
+  /** Click-only by construction, which is what keeps playback out of it. */
+  protected requestReveal() {
+    this.dispatchEvent(
+      new CustomEvent<RowRevealKey | undefined>('row-reveal', {
+        detail: this.revealKey,
+        bubbles: true,
+        composed: true
+      })
+    )
   }
 
   static styles = [

--- a/packages/app/src/components/workbench/actionItems/mutation.ts
+++ b/packages/app/src/components/workbench/actionItems/mutation.ts
@@ -28,7 +28,7 @@ export class MutationItem extends ActionItem {
       ${this.iconChip(
         html`<icon-mdi-pencil class="${ICON_CLASS}"></icon-mdi-pencil>`
       )}
-      <span class="flex-grow text-left"
+      <span class="label"
         >element attribute "<code>${mutation.attributeName}</code>"
         changed</span
       >
@@ -42,7 +42,7 @@ export class MutationItem extends ActionItem {
         ${this.iconChip(
           html`<icon-mdi-document class="${ICON_CLASS}"></icon-mdi-document>`
         )}
-        <span class="flex-grow text-left">Document loaded</span>
+        <span class="label">Document loaded</span>
         ${this.renderTime()}
       `
     }
@@ -52,7 +52,7 @@ export class MutationItem extends ActionItem {
           class="${ICON_CLASS}"
         ></icon-mdi-family-tree>`
       )}
-      <span class="flex-grow text-left">
+      <span class="label">
         ${this.#renderNodeAmount(mutation.addedNodes, 'added')}
         ${mutation.addedNodes.length && mutation.removedNodes.length
           ? ' and '
@@ -78,6 +78,7 @@ export class MutationItem extends ActionItem {
   }
 
   #selectMutation() {
+    this.toggleRevealed()
     const event = new CustomEvent('app-mutation-select', { detail: this.entry })
     window.dispatchEvent(event)
     this.requestUpdate()

--- a/packages/app/src/components/workbench/actionItems/mutation.ts
+++ b/packages/app/src/components/workbench/actionItems/mutation.ts
@@ -78,7 +78,7 @@ export class MutationItem extends ActionItem {
   }
 
   #selectMutation() {
-    this.toggleRevealed()
+    this.requestReveal()
     const event = new CustomEvent('app-mutation-select', { detail: this.entry })
     window.dispatchEvent(event)
     this.requestUpdate()

--- a/packages/app/src/components/workbench/actions.ts
+++ b/packages/app/src/components/workbench/actions.ts
@@ -1,6 +1,7 @@
 import { Element } from '@core/element'
 import { html, css, nothing } from 'lit'
 import { customElement, state } from 'lit/decorators.js'
+import { repeat } from 'lit/directives/repeat.js'
 import { consume } from '@lit/context'
 
 import type {
@@ -18,12 +19,14 @@ import '../placeholder.js'
 import './actionItems/command.js'
 import './actionItems/group.js'
 import './actionItems/mutation.js'
+import type { RowRevealKey } from './actionItems/item.js'
 import { elapsedSince } from '../../utils/elapsed.js'
 import { entryDuration, stepDurations } from './actionItems/duration.js'
 import { activeSpanAt } from './active-entry.js'
 import {
   defaultExpanded,
   flattenActionTree,
+  rowKey,
   type ActionTreeRow
 } from './action-tree.js'
 
@@ -96,6 +99,17 @@ export class DevtoolsActions extends Element {
   // (failed or containing the active command → open).
   @state()
   private expandOverrides: ReadonlyMap<string, boolean> = new Map()
+
+  // The one row showing its label in full. Held here, not per row, so clicking
+  // a row folds whichever was open — otherwise every row the user ever clicked
+  // stays wrapped and the panel goes ragged again.
+  @state()
+  private revealedRow?: RowRevealKey
+
+  #onRowReveal = (event: Event) => {
+    const key = (event as CustomEvent<RowRevealKey | undefined>).detail
+    this.revealedRow = key === this.revealedRow ? undefined : key
+  }
 
   #onGroupToggle = (event: Event) => {
     const { callId, expanded } = (
@@ -201,8 +215,12 @@ export class DevtoolsActions extends Element {
       defaultExpanded(group, activeIndex >= 0 ? activeIndex : undefined)
     const rows = flattenActionTree(rootChildren, isExpanded)
     const gaps = stepDurations(commands.map((command) => command.timestamp))
-    return html`<div class="timeline tree" @group-toggle=${this.#onGroupToggle}>
-      ${rows.map((row) => this.#renderTreeRow(row, commands, gaps))}
+    return html`<div
+      class="timeline tree"
+      @group-toggle=${this.#onGroupToggle}
+      @row-reveal=${this.#onRowReveal}
+    >
+      ${repeat(rows, rowKey, (row) => this.#renderTreeRow(row, commands, gaps))}
     </div>`
   }
 
@@ -212,12 +230,15 @@ export class DevtoolsActions extends Element {
     gaps: Array<number | undefined>
   ) {
     const indent = `padding-left: ${row.depth * TREE_INDENT_PX}px`
+    const key = rowKey(row)
     if (row.kind === 'group') {
       return html`
         <wdio-devtools-group-item
           style=${indent}
           .group=${row.group}
           ?expanded=${row.expanded}
+          .revealKey=${key}
+          ?revealed=${key === this.revealedRow}
         ></wdio-devtools-group-item>
       `
     }
@@ -234,6 +255,8 @@ export class DevtoolsActions extends Element {
         .duration=${duration}
         .entry=${entry}
         ?active=${entry === this.activeEntry}
+        .revealKey=${key}
+        ?revealed=${key === this.revealedRow}
       ></wdio-devtools-command-item>
     `
   }
@@ -249,35 +272,50 @@ export class DevtoolsActions extends Element {
     }
     const durations = stepDurations(entries.map((entry) => entry.timestamp))
 
-    const rows = entries.map((entry, index) => {
-      // Timed against the merged list, so the top row always reads zero — a
-      // document load can precede the first command.
-      const elapsedTime = elapsedSince(entries, entry)
-      const duration = entryDuration(entry, durations[index])
-      const active = entry === this.activeEntry
+    // Keyed by reference, the same identity `activeEntry` uses: timestamps
+    // aren't unique, and an index would hand a row's local state to whatever
+    // entry sorts into that position next.
+    const rows = repeat(
+      entries,
+      (entry) => entry,
+      (entry, index) => {
+        // Timed against the merged list, so the top row always reads zero — a
+        // document load can precede the first command.
+        const elapsedTime = elapsedSince(entries, entry)
+        const duration = entryDuration(entry, durations[index])
+        const active = entry === this.activeEntry
 
-      if ('command' in entry) {
+        const revealed = entry === this.revealedRow
+
+        if ('command' in entry) {
+          return html`
+            <wdio-devtools-command-item
+              elapsedTime=${elapsedTime}
+              .duration=${duration}
+              .entry=${entry}
+              ?active=${active}
+              .revealKey=${entry}
+              ?revealed=${revealed}
+            ></wdio-devtools-command-item>
+          `
+        }
+
         return html`
-          <wdio-devtools-command-item
+          <wdio-devtools-mutation-item
             elapsedTime=${elapsedTime}
             .duration=${duration}
             .entry=${entry}
             ?active=${active}
-          ></wdio-devtools-command-item>
+            .revealKey=${entry}
+            ?revealed=${revealed}
+          ></wdio-devtools-mutation-item>
         `
       }
+    )
 
-      return html`
-        <wdio-devtools-mutation-item
-          elapsedTime=${elapsedTime}
-          .duration=${duration}
-          .entry=${entry}
-          ?active=${active}
-        ></wdio-devtools-mutation-item>
-      `
-    })
-
-    return html`<div class="timeline">${rows}</div>`
+    return html`<div class="timeline" @row-reveal=${this.#onRowReveal}>
+      ${rows}
+    </div>`
   }
 }
 

--- a/packages/app/src/components/workbench/actions.ts
+++ b/packages/app/src/components/workbench/actions.ts
@@ -43,6 +43,10 @@ export class DevtoolsActions extends Element {
         display: flex;
         flex-direction: column;
         width: 100%;
+        /* The panel's width is fixed by its drag handle; single-line rows must
+           clip inside it rather than widen it (or scroll it) to fit. */
+        min-width: 0;
+        overflow-x: hidden;
       }
 
       /* Wraps the rows so the rail spans the full content height — the host

--- a/packages/app/test-ui/sidebar/explorer/explorer.test.ts
+++ b/packages/app/test-ui/sidebar/explorer/explorer.test.ts
@@ -39,6 +39,7 @@ const NESTED_GROUP = 'wdio-test-suite[slot="children"]'
 const ROOT_ROW = 'wdio-test-entry[root]'
 const TEST_ROW = 'wdio-test-entry[entry-type="test"]'
 const SELECTED_ROW = 'wdio-test-entry[selected]'
+const REVEALED_ROW = 'wdio-test-entry[revealed]'
 const ROW_LABEL = 'wdio-test-entry > label'
 const EMPTY_STATE = 'p.text-disabledForeground'
 // Located by its icon, not its title: the title carries the refusal reason when
@@ -614,6 +615,53 @@ describe('wdio-devtools-sidebar-explorer', () => {
       expect(rowUids(explorer, SELECTED_ROW)).toEqual([
         mixedStateRun.passing.uid
       ])
+    })
+
+    // The highlight follows the run on its own; reflowing a name must not, or a
+    // row nobody clicked grows — and a different one as the run moves on.
+    it('reflows no name while the highlight tracks the running test', async () => {
+      const explorer = await mountExplorer(mixedStateRun.registry)
+
+      expect(rowUids(explorer, REVEALED_ROW)).toEqual([])
+    })
+  })
+
+  describe('reveal', () => {
+    it('reflows the name of the row that is clicked', async () => {
+      const explorer = await mountExplorer(mixedStateRun.registry)
+
+      shadow(rowByUid(explorer, mixedStateRun.passing.uid), LABEL_SPAN)?.click()
+      await settle(explorer)
+
+      expect(rowUids(explorer, REVEALED_ROW)).toEqual([
+        mixedStateRun.passing.uid
+      ])
+    })
+
+    // One name at a time: every row the user had ever clicked used to stay
+    // wrapped, which is the ragged tree the single-line rows were meant to fix.
+    it('folds the previous name when another row is clicked', async () => {
+      const explorer = await mountExplorer(mixedStateRun.registry)
+
+      shadow(rowByUid(explorer, mixedStateRun.passing.uid), LABEL_SPAN)?.click()
+      await settle(explorer)
+      shadow(rowByUid(explorer, mixedStateRun.failing.uid), LABEL_SPAN)?.click()
+      await settle(explorer)
+
+      expect(rowUids(explorer, REVEALED_ROW)).toEqual([
+        mixedStateRun.failing.uid
+      ])
+    })
+
+    it('folds a reflowed name when its own row is clicked again', async () => {
+      const explorer = await mountExplorer(mixedStateRun.registry)
+
+      shadow(rowByUid(explorer, mixedStateRun.passing.uid), LABEL_SPAN)?.click()
+      await settle(explorer)
+      shadow(rowByUid(explorer, mixedStateRun.passing.uid), LABEL_SPAN)?.click()
+      await settle(explorer)
+
+      expect(rowUids(explorer, REVEALED_ROW)).toEqual([])
     })
   })
 

--- a/packages/app/test-ui/sidebar/explorer/test-entry.test.ts
+++ b/packages/app/test-ui/sidebar/explorer/test-entry.test.ts
@@ -2,6 +2,7 @@ import '@components/sidebar/test-suite.js'
 import type { ExplorerTestEntry } from '@components/sidebar/test-suite.js'
 import type { TestRunDetail } from '@components/sidebar/types.js'
 
+import { capture } from '../../support/events.js'
 import { mount, settle } from '../../support/mount.js'
 import { shadow, shadowAll, text } from '../../support/queries.js'
 import {
@@ -59,22 +60,6 @@ async function mountRow(
   row.append(title)
   await settle(row)
   return row
-}
-
-function capture<T>(
-  target: EventTarget,
-  type: string,
-  act: () => void
-): CustomEvent<T>[] {
-  const received: CustomEvent<T>[] = []
-  const listener = (event: Event) => received.push(event as CustomEvent<T>)
-  target.addEventListener(type, listener)
-  try {
-    act()
-  } finally {
-    target.removeEventListener(type, listener)
-  }
-  return received
 }
 
 describe('wdio-test-entry', () => {
@@ -189,16 +174,24 @@ describe('wdio-test-entry', () => {
       expect(row.hasAttribute('revealed')).toBe(false)
     })
 
-    it('reflows the name on click and folds it back on a second click', async () => {
+    // The explorer owns which row is reflowed, so one click can fold another
+    // row; a row that reflowed itself would leave both open.
+    it('does not reflow itself on click', async () => {
       const row = await mountRow(rowProps(mixedStateRun.failing))
 
       shadow(row, LABEL_SPAN)?.click()
       await settle(row)
-      expect(row.hasAttribute('revealed')).toBe(true)
 
-      shadow(row, LABEL_SPAN)?.click()
-      await settle(row)
       expect(row.hasAttribute('revealed')).toBe(false)
+    })
+
+    it('reflows its name when the explorer reveals it', async () => {
+      const row = await mountRow({
+        ...rowProps(mixedStateRun.failing),
+        revealed: true
+      })
+
+      expect(row.hasAttribute('revealed')).toBe(true)
     })
 
     // The tree auto-selects the running test, so a selected row that reflowed

--- a/packages/app/test-ui/sidebar/explorer/test-entry.test.ts
+++ b/packages/app/test-ui/sidebar/explorer/test-entry.test.ts
@@ -182,6 +182,37 @@ describe('wdio-test-entry', () => {
     })
   })
 
+  describe('reveal', () => {
+    it('keeps a name on one line until the row is clicked', async () => {
+      const row = await mountRow(rowProps(mixedStateRun.failing))
+
+      expect(row.hasAttribute('revealed')).toBe(false)
+    })
+
+    it('reflows the name on click and folds it back on a second click', async () => {
+      const row = await mountRow(rowProps(mixedStateRun.failing))
+
+      shadow(row, LABEL_SPAN)?.click()
+      await settle(row)
+      expect(row.hasAttribute('revealed')).toBe(true)
+
+      shadow(row, LABEL_SPAN)?.click()
+      await settle(row)
+      expect(row.hasAttribute('revealed')).toBe(false)
+    })
+
+    // The tree auto-selects the running test, so a selected row that reflowed
+    // would grow a row nobody clicked — and mid-run, a different one each time.
+    it('does not reflow a row the tree merely selected', async () => {
+      const row = await mountRow({
+        ...rowProps(mixedStateRun.running),
+        selected: true
+      })
+
+      expect(row.hasAttribute('revealed')).toBe(false)
+    })
+  })
+
   describe('selection', () => {
     it('announces its uid on app-test-select when the row is clicked', async () => {
       const row = await mountRow(rowProps(mixedStateRun.failing))

--- a/packages/app/test-ui/sidebar/fixtures.ts
+++ b/packages/app/test-ui/sidebar/fixtures.ts
@@ -294,6 +294,7 @@ export type TestEntryProps = Partial<
     | 'suiteType'
     | 'hasChildren'
     | 'selected'
+    | 'revealed'
     | 'root'
     | 'runDisabled'
     | 'runDisabledReason'

--- a/packages/app/test-ui/support/events.ts
+++ b/packages/app/test-ui/support/events.ts
@@ -1,0 +1,18 @@
+/** Collect the events of one type a component emits while `act` runs. Removes
+ *  the listener even when `act` throws, so one failing spec can't leak into the
+ *  next one's counts. */
+export function capture<T>(
+  target: EventTarget,
+  type: string,
+  act: () => void
+): CustomEvent<T>[] {
+  const received: CustomEvent<T>[] = []
+  const listener = (event: Event) => received.push(event as CustomEvent<T>)
+  target.addEventListener(type, listener)
+  try {
+    act()
+  } finally {
+    target.removeEventListener(type, listener)
+  }
+  return received
+}

--- a/packages/app/test-ui/workbench/actions/actions.test.ts
+++ b/packages/app/test-ui/workbench/actions/actions.test.ts
@@ -152,6 +152,12 @@ const elapsedOf = (row: Element) =>
 
 const clickRow = (row: Element) => shadow(row, 'button')?.click()
 
+/** Actions of the rows currently showing their label in full. */
+const revealedOf = (panel: Element): TimelineEntry[] =>
+  shadowAll(panel, `${COMMAND_ROW}[revealed], ${MUTATION_ROW}[revealed]`)
+    .map(entryOf)
+    .filter((entry): entry is TimelineEntry => Boolean(entry))
+
 describe('wdio-devtools-actions', () => {
   describe('merged timeline', () => {
     it('orders commands and document loads into a single list by timestamp', async () => {
@@ -435,6 +441,45 @@ describe('wdio-devtools-actions', () => {
       ])
       expect(rows.map(elapsedOf)).toEqual([0, 300, 700, 900, 1600])
       expect(rows.map(durationOf)).toEqual([300, 300, 200, 700, 700])
+    })
+
+    // One row at a time: every row the user had ever clicked used to stay
+    // wrapped, which is the ragged panel the single-line rows were meant to fix.
+    it('reflows only the row clicked last', async () => {
+      const panel = await mountPanel({ groups })
+
+      clickRow(shadowAll(panel, ROWS)[2])
+      await settle(panel)
+      expect(revealedOf(panel)).toEqual([loginTimeline.findInput])
+
+      clickRow(shadowAll(panel, ROWS)[3])
+      await settle(panel)
+
+      expect(revealedOf(panel)).toEqual([loginTimeline.setValue])
+    })
+
+    it('folds a reflowed row when it is clicked again', async () => {
+      const panel = await mountPanel({ groups })
+
+      clickRow(shadowAll(panel, ROWS)[2])
+      await settle(panel)
+      clickRow(shadowAll(panel, ROWS)[2])
+      await settle(panel)
+
+      expect(revealedOf(panel)).toEqual([])
+    })
+
+    // A step row and an action row compete for the same single reveal.
+    it('folds a reflowed action when a step row is clicked', async () => {
+      const panel = await mountPanel({ groups })
+
+      clickRow(shadowAll(panel, ROWS)[2])
+      await settle(panel)
+      clickRow(shadowAll(panel, ROWS)[0])
+      await settle(panel)
+
+      expect(revealedOf(panel)).toEqual([])
+      expect(shadowAll(panel, GROUP_ROW)[0].hasAttribute('revealed')).toBe(true)
     })
 
     it("reveals a collapsed group's commands when the group row is clicked", async () => {

--- a/packages/app/test-ui/workbench/actions/command-item.test.ts
+++ b/packages/app/test-ui/workbench/actions/command-item.test.ts
@@ -4,6 +4,7 @@ import '@components/workbench/actionItems/command.js'
 import type { CommandItem } from '@components/workbench/actionItems/command.js'
 import { entryDuration } from '@components/workbench/actionItems/duration.js'
 
+import { capture } from '../../support/events.js'
 import { mount, settle } from '../../support/mount.js'
 import { shadow, shadowAll, text } from '../../support/queries.js'
 import { commandLog } from '../../support/builders.js'
@@ -171,17 +172,29 @@ describe('wdio-devtools-command-item', () => {
       expect(el.hasAttribute('revealed')).toBe(false)
     })
 
-    it('reflows the label on click and folds it back on a second click', async () => {
-      const el = await mount<CommandItem>(TAG, {
-        entry: commandLog({ command: 'click' })
-      })
+    // The row asks; the panel decides, so only one row is ever reflowed.
+    it('reports its reveal key on click for the panel to act on', async () => {
+      const entry = commandLog({ command: 'click' })
+      const el = await mount<CommandItem>(TAG, { entry, revealKey: entry })
+
+      const received = capture<CommandLog>(el, 'row-reveal', () =>
+        shadow(el, 'button')?.dispatchEvent(new MouseEvent('click'))
+      )
+
+      expect(received).toHaveLength(1)
+      expect(received[0]?.detail).toBe(entry)
+      // Composed so it survives the panel's shadow boundary, where it listens.
+      expect(received[0]?.bubbles).toBe(true)
+      expect(received[0]?.composed).toBe(true)
+    })
+
+    it('does not reflow itself on click', async () => {
+      const entry = commandLog({ command: 'click' })
+      const el = await mount<CommandItem>(TAG, { entry, revealKey: entry })
 
       shadow(el, 'button')?.dispatchEvent(new MouseEvent('click'))
       await settle(el)
-      expect(el.hasAttribute('revealed')).toBe(true)
 
-      shadow(el, 'button')?.dispatchEvent(new MouseEvent('click'))
-      await settle(el)
       expect(el.hasAttribute('revealed')).toBe(false)
     })
 

--- a/packages/app/test-ui/workbench/actions/command-item.test.ts
+++ b/packages/app/test-ui/workbench/actions/command-item.test.ts
@@ -162,6 +162,41 @@ describe('wdio-devtools-command-item', () => {
     })
   })
 
+  describe('reveal', () => {
+    it('keeps a row on one line until it is clicked', async () => {
+      const el = await mount<CommandItem>(TAG, {
+        entry: commandLog({ command: 'click' })
+      })
+
+      expect(el.hasAttribute('revealed')).toBe(false)
+    })
+
+    it('reflows the label on click and folds it back on a second click', async () => {
+      const el = await mount<CommandItem>(TAG, {
+        entry: commandLog({ command: 'click' })
+      })
+
+      shadow(el, 'button')?.dispatchEvent(new MouseEvent('click'))
+      await settle(el)
+      expect(el.hasAttribute('revealed')).toBe(true)
+
+      shadow(el, 'button')?.dispatchEvent(new MouseEvent('click'))
+      await settle(el)
+      expect(el.hasAttribute('revealed')).toBe(false)
+    })
+
+    // The player clock marks the action at the playhead as active, so an active
+    // row that reflowed would make every row height depend on playback.
+    it('does not reflow a row the playhead merely made active', async () => {
+      const el = await mount<CommandItem>(TAG, {
+        entry: commandLog({ command: 'click' }),
+        active: true
+      })
+
+      expect(el.hasAttribute('revealed')).toBe(false)
+    })
+  })
+
   describe('state', () => {
     it('leaves the row unmarked when the entry has no error', async () => {
       const el = await mount<CommandItem>(TAG, {

--- a/packages/app/test-ui/workbench/actions/group-item.test.ts
+++ b/packages/app/test-ui/workbench/actions/group-item.test.ts
@@ -5,7 +5,7 @@ import { mount, settle } from '../../support/mount.js'
 import { shadow, shadowAll, text } from '../../support/queries.js'
 
 const TAG = 'wdio-devtools-group-item'
-const LABEL = 'span.break-all'
+const LABEL = 'span.label'
 const BADGE = '.ml-auto'
 const CHEVRON = 'icon-mdi-chevron-right'
 
@@ -151,6 +151,29 @@ describe('wdio-devtools-group-item', () => {
     }
 
     expect(received[0]?.detail.expanded).toBe(true)
+  })
+
+  // Groups auto-expand when they failed or hold the active command, so an
+  // expanded row that reflowed would be a step nobody clicked taking two lines.
+  it('does not reflow the title of a group that was expanded for it', async () => {
+    const el = await mount<GroupItem>(TAG, {
+      group: { ...STEP, failed: true },
+      expanded: true
+    })
+
+    expect(el.hasAttribute('revealed')).toBe(false)
+  })
+
+  it('reflows the title on click and folds it back on a second click', async () => {
+    const el = await mount<GroupItem>(TAG, { group: { ...STEP } })
+
+    shadow(el, 'button')?.dispatchEvent(new MouseEvent('click'))
+    await settle(el)
+    expect(el.hasAttribute('revealed')).toBe(true)
+
+    shadow(el, 'button')?.dispatchEvent(new MouseEvent('click'))
+    await settle(el)
+    expect(el.hasAttribute('revealed')).toBe(false)
   })
 
   it('does not toggle its own expanded state when clicked', async () => {

--- a/packages/app/test-ui/workbench/actions/group-item.test.ts
+++ b/packages/app/test-ui/workbench/actions/group-item.test.ts
@@ -1,6 +1,7 @@
 import '@components/workbench/actionItems/group.js'
 import type { GroupItem } from '@components/workbench/actionItems/group.js'
 
+import { capture } from '../../support/events.js'
 import { mount, settle } from '../../support/mount.js'
 import { shadow, shadowAll, text } from '../../support/queries.js'
 
@@ -164,15 +165,29 @@ describe('wdio-devtools-group-item', () => {
     expect(el.hasAttribute('revealed')).toBe(false)
   })
 
-  it('reflows the title on click and folds it back on a second click', async () => {
+  // The row asks; the panel decides, so only one row is ever reflowed.
+  it('reports its reveal key on click for the panel to act on', async () => {
+    const el = await mount<GroupItem>(TAG, {
+      group: { ...STEP },
+      revealKey: 'group:step-7'
+    })
+
+    const received = capture<string>(el, 'row-reveal', () =>
+      shadow(el, 'button')?.dispatchEvent(new MouseEvent('click'))
+    )
+
+    expect(received).toHaveLength(1)
+    expect(received[0]?.detail).toBe('group:step-7')
+    expect(received[0]?.bubbles).toBe(true)
+    expect(received[0]?.composed).toBe(true)
+  })
+
+  it('does not reflow itself on click', async () => {
     const el = await mount<GroupItem>(TAG, { group: { ...STEP } })
 
     shadow(el, 'button')?.dispatchEvent(new MouseEvent('click'))
     await settle(el)
-    expect(el.hasAttribute('revealed')).toBe(true)
 
-    shadow(el, 'button')?.dispatchEvent(new MouseEvent('click'))
-    await settle(el)
     expect(el.hasAttribute('revealed')).toBe(false)
   })
 

--- a/packages/app/test-ui/workbench/actions/mutation-item.test.ts
+++ b/packages/app/test-ui/workbench/actions/mutation-item.test.ts
@@ -7,7 +7,7 @@ import { shadow, shadowAll, text } from '../../support/queries.js'
 import { mutation, documentLoaded } from '../../support/builders.js'
 
 const TAG = 'wdio-devtools-mutation-item'
-const LABEL = 'span.flex-grow'
+const LABEL = 'span.label'
 const BADGE = '.ml-auto'
 const PAGE_URL = 'https://the-internet.herokuapp.com/login'
 

--- a/packages/app/tests/action-tree.test.ts
+++ b/packages/app/tests/action-tree.test.ts
@@ -7,7 +7,8 @@ import type {
 import {
   collectCommandIndices,
   defaultExpanded,
-  flattenActionTree
+  flattenActionTree,
+  rowKey
 } from '../src/components/workbench/action-tree.js'
 
 function group(
@@ -91,5 +92,32 @@ describe('flattenActionTree', () => {
         row.kind === 'group' ? row.group.callId : row.commandIndex
       )
     ).toEqual(['hook', 'fixture', 2, 3])
+  })
+})
+
+describe('rowKey', () => {
+  it('keys a group row on its callId', () => {
+    expect(
+      rowKey({ kind: 'group', group: NESTED, depth: 0, expanded: true })
+    ).toBe('group:hook')
+  })
+
+  it('keys a command row on its command index', () => {
+    expect(rowKey({ kind: 'command', commandIndex: 2, depth: 1 })).toBe(
+      'command:2'
+    )
+  })
+
+  it('separates a numeric callId from the command index it reads as', () => {
+    const numeric = rowKey({
+      kind: 'group',
+      group: group('2', []),
+      depth: 0,
+      expanded: false
+    })
+
+    expect(numeric).not.toBe(
+      rowKey({ kind: 'command', commandIndex: 2, depth: 0 })
+    )
   })
 })


### PR DESCRIPTION
## What & why

[//]: # (What does this PR change, and what problem does it solve? Link the issue it closes, if any.)

## Type of change

[//]: # (Put an `x` in the boxes that apply.)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Polish (an improvement to an existing feature)
- [ ] Breaking change (existing behavior changes for users)
- [ ] Documentation
- [ ] Internal (build, CI, dependencies, tooling)

## Packages touched

[//]: # (DevTools is a monorepo — checking these helps reviewers know where to look.)

- [ ] `shared` (types and contracts)
- [ ] `core` (framework-agnostic capture/reporting)
- [ ] `elements` (published element/snapshot API — `@wdio/elements`)
- [ ] `service` (WebdriverIO adapter)
- [ ] `nightwatch-devtools` (Nightwatch adapter)
- [ ] `selenium-devtools` (Selenium adapter)
- [ ] `backend` (server)
- [x] `app` (UI)
- [ ] `script` (page-injected runtime)

## Notes for reviewers

[//]: # (Anything non-obvious: design trade-offs, alternatives you ruled out, follow-ups. If this PR touches more than one adapter, say why the shared logic doesn't live in `core`.)

## Screenshots / recordings

[//]: # (Required for UI changes — before/after images or a short clip.)
